### PR TITLE
Only override default for posArgs when there is at least one given

### DIFF
--- a/src/main/java/net/sourceforge/argparse4j/internal/ArgumentImpl.java
+++ b/src/main/java/net/sourceforge/argparse4j/internal/ArgumentImpl.java
@@ -24,6 +24,7 @@
 package net.sourceforge.argparse4j.internal;
 
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -404,7 +405,11 @@ public final class ArgumentImpl implements Argument {
 
     @Override
     public Object getDefault() {
-        return default_;
+        if (default_ == null && maxNumArg_ > 1) {
+            return new ArrayList<Object>();
+        } else {
+            return default_;
+        }
     }
 
     @Override

--- a/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
+++ b/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
@@ -685,7 +685,9 @@ public final class ArgumentParserImpl implements ArgumentParser {
                     throw new ArgumentParserException("too few arguments", this);
                 }
             }
-            arg.run(this, res, flag, list);
+            if (!list.isEmpty()) {
+                arg.run(this, res, flag, list);
+            }
         }
     }
 

--- a/src/test/java/net/sourceforge/argparse4j/internal/ArgumentParserImplTest.java
+++ b/src/test/java/net/sourceforge/argparse4j/internal/ArgumentParserImplTest.java
@@ -17,9 +17,13 @@ import java.io.FileInputStream;
 import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import net.sourceforge.argparse4j.annotation.Arg;
+import net.sourceforge.argparse4j.inf.Argument;
+import net.sourceforge.argparse4j.inf.ArgumentAction;
 import net.sourceforge.argparse4j.inf.ArgumentGroup;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
@@ -330,6 +334,34 @@ public class ArgumentParserImplTest {
         assertEquals("FOO", res.get("foo"));
         assertEquals("bar", res.get("g"));
         assertEquals("input", res.get("i"));
+    }
+
+    @Test
+    public void testParseArgsWithsPosargNargsDefaults() throws ArgumentParserException {
+
+        class MockAction implements ArgumentAction {
+            boolean invoked;
+
+            @Override
+            public void run(ArgumentParser parser, Argument arg,
+                    Map<String, Object> attrs, String flag, Object value)
+                    throws ArgumentParserException {
+                invoked = true;
+            }
+
+            @Override
+            public void onAttach(Argument arg) {}
+
+            @Override
+            public boolean consumeArgument() { return true; }
+        }
+
+        ap.addArgument("f").nargs("*").setDefault(list("default"));
+        MockAction action = new MockAction();
+        ap.addArgument("b").nargs("*").setDefault(false).action(action);
+        Namespace res = ap.parseArgs(new String[] {});
+        assertEquals(list("default"), res.get("f"));
+        assertEquals(false, action.invoked);
     }
 
     @Test


### PR DESCRIPTION
Also updated an existing (failing) test case since I don't expect
the default (null) to change if no parameter is provided, i.e. I
expect posargs to have the same behavior as optargs (test added for
showing the symmetry).
