### PR TITLE
make getFormatWidth() public.

### DIFF
--- a/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
+++ b/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
@@ -238,7 +238,7 @@ public final class ArgumentParserImpl implements ArgumentParser {
      * 
      * @return
      */
-    private int getFormatWidth() {
+    public int getFormatWidth() {
         if (ArgumentParsers.getTerminalWidthDetection()) {
             int w = new TerminalWidth().getTerminalWidth() - 5;
             return w <= 0 ? FORMAT_WIDTH : w;


### PR DESCRIPTION
make getFormatWidth() public. I need this to format supplementary text with the same style, for consistent look and feel.
