### PR TITLE
Added shortcut method to parse arguments and handle errors at the same time.

### DIFF
--- a/src/main/java/net/sourceforge/argparse4j/inf/ArgumentParser.java
+++ b/src/main/java/net/sourceforge/argparse4j/inf/ArgumentParser.java
@@ -281,6 +281,24 @@ public interface ArgumentParser {
 
     /**
      * <p>
+     * Parses command line arguments, handling any errors.
+     * </p>
+     * <p>
+     * This is a shortcut method that combines {@link #parseArgs} and 
+     * {@link #handleError }. If the arguments can be successfully parsed,
+     * the resulted attributes are returned as a {@link Namespace} object.
+     * Otherwise, the program exists with a <code>1</code> return code.
+     *
+     * </p>
+     * 
+     * @param args
+     *            Command line arguments.
+     * @return {@link Namespace} object.
+     */
+    Namespace parseArgsOrFail(String args[]);
+
+    /**
+     * <p>
      * Parses command line arguments.
      * </p>
      * <p>

--- a/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
+++ b/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
@@ -532,6 +532,18 @@ public final class ArgumentParserImpl implements ArgumentParser {
     }
 
     @Override
+    public Namespace parseArgsOrFail(String args[]) {
+        try {
+            Namespace ns = parseArgs(args);
+            return ns;
+        } catch (ArgumentParserException e) {
+            handleError(e);
+            System.exit(1);
+        }
+        return null;
+    }
+
+    @Override
     public Namespace parseArgs(String args[]) throws ArgumentParserException {
         Map<String, Object> attrs = new HashMap<String, Object>();
         parseArgs(args, attrs);

--- a/src/main/java/net/sourceforge/argparse4j/internal/SubparserImpl.java
+++ b/src/main/java/net/sourceforge/argparse4j/internal/SubparserImpl.java
@@ -167,6 +167,11 @@ public final class SubparserImpl implements Subparser {
     }
 
     @Override
+    public Namespace parseArgsOrFail(String args[]) {
+        return parser_.parseArgsOrFail(args);
+    }
+
+    @Override
     public Namespace parseArgs(String[] args) throws ArgumentParserException {
         return parser_.parseArgs(args);
     }


### PR DESCRIPTION
I created a shortcut method to parse arguments and handle errors at the same time.

It's a wrapper for the `parseArgs(args)` method that catches an `ArgumentParserException`, prints the error message and exits. If no error occurs, it just returns the `Namespace` object.

I find this method useful since it simplifies the most common use case for handling arguments.
