### PR TITLE
Add the compiler plugin to the Maven project file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,13 @@
 				<configuration>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.0</version>
+				<configuration>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Hello,

I added the compiler plugin to the Maven file (pom.xml). This allowed me to build the project from the command line; without adding it, it was necessary to specify the minor Java version supported (since it was not possible to do it with the default ones).
