### PR TITLE
Fixed bug where System.out got closed in printHelp

### DIFF
--- a/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
+++ b/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
@@ -260,7 +260,6 @@ public final class ArgumentParserImpl implements ArgumentParser {
     public void printHelp() {
         PrintWriter writer = new PrintWriter(System.out);
         printHelp(writer);
-        writer.close();
     }
 
     @Override


### PR DESCRIPTION
- ArgumentParserImpl creates a PrintWriter upon printing help that wraps
  System.out, however, it also closes that PrintWriter before exiting the
  method, which in turn, closes System.out.  This meant that any calls to
  System.out.\* by any other method would fail to get output.  See:
  http://stackoverflow.com/questions/8941298/system-out-closed-can-i-reopen-it
  for details of this problem.
