### PR TITLE
Changed HelpArgumentAction to throw exception rather than exit

### DIFF
--- a/src/main/java/net/sourceforge/argparse4j/impl/action/HelpArgumentAction.java
+++ b/src/main/java/net/sourceforge/argparse4j/impl/action/HelpArgumentAction.java
@@ -29,6 +29,7 @@ import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.ArgumentAction;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.internal.HelpScreenException;
 
 /**
  * <p>
@@ -36,9 +37,9 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
  * </p>
  * <p>
  * Please note that this
- * {@link #run(ArgumentParser, Argument, Map, String, Object)} terminates
- * program after printing the help message. {@link #consumeArgument()} always
- * returns {@code false}.
+ * {@link #run(ArgumentParser, Argument, Map, String, Object)} always throws a
+ * {@code HelpScreenException} exception after printing the help message.
+ * {@link #consumeArgument()} always returns {@code false}.
  * </p>
  * 
  */
@@ -49,7 +50,7 @@ public class HelpArgumentAction implements ArgumentAction {
             Map<String, Object> attrs, String flag, Object value)
             throws ArgumentParserException {
         parser.printHelp();
-        System.exit(0);
+        throw new HelpScreenException(parser);
     }
 
     @Override

--- a/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
+++ b/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
@@ -57,7 +57,6 @@ import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import net.sourceforge.argparse4j.inf.Namespace;
-import net.sourceforge.argparse4j.inf.Subparsers;
 
 /**
  * <strong>The application code must not use this class directly.</strong>
@@ -1126,6 +1125,10 @@ public final class ArgumentParserImpl implements ArgumentParser {
     public void handleError(ArgumentParserException e) {
         if (e.getParser() != this) {
             e.getParser().handleError(e);
+            return;
+        }
+        // if --help triggered, just return (help info displayed by other method)
+        if (e instanceof HelpScreenException) {
             return;
         }
         PrintWriter writer = new PrintWriter(System.err);

--- a/src/main/java/net/sourceforge/argparse4j/internal/HelpScreenException.java
+++ b/src/main/java/net/sourceforge/argparse4j/internal/HelpScreenException.java
@@ -1,0 +1,15 @@
+package net.sourceforge.argparse4j.internal;
+
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+
+
+public class HelpScreenException extends ArgumentParserException {
+
+    private static final long serialVersionUID = -7303433847334132539L;
+
+    public HelpScreenException(ArgumentParser parser) {
+        super("Help Screen", parser);
+    }
+}
+

--- a/src/test/java/net/sourceforge/argparse4j/internal/ArgumentParserImplTest.java
+++ b/src/test/java/net/sourceforge/argparse4j/internal/ArgumentParserImplTest.java
@@ -1,19 +1,8 @@
 package net.sourceforge.argparse4j.internal;
 
-import static net.sourceforge.argparse4j.impl.Arguments.SUPPRESS;
-import static net.sourceforge.argparse4j.impl.Arguments.append;
-import static net.sourceforge.argparse4j.impl.Arguments.appendConst;
-import static net.sourceforge.argparse4j.impl.Arguments.count;
-import static net.sourceforge.argparse4j.impl.Arguments.range;
-import static net.sourceforge.argparse4j.impl.Arguments.storeConst;
-import static net.sourceforge.argparse4j.impl.Arguments.storeFalse;
-import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
-import static net.sourceforge.argparse4j.test.TestHelper.list;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static net.sourceforge.argparse4j.impl.Arguments.*;
+import static net.sourceforge.argparse4j.test.TestHelper.*;
+import static org.junit.Assert.*;
 
 import java.io.FileInputStream;
 import java.io.PrintWriter;
@@ -1239,5 +1228,10 @@ public class ArgumentParserImplTest {
         assertFalse(foo.hashCode() == foo2.hashCode());
         assertFalse(foo.hashCode() == bar.hashCode());
         assertFalse(foo.hashCode() == subNull.hashCode());
+    }
+    
+    @Test (expected=HelpScreenException.class)
+    public void testHelpThrowsHelpScreenException() throws ArgumentParserException {
+        ap.parseArgs(new String[]{"--help"});
     }
 }


### PR DESCRIPTION
- As it stood, HelpArgumentAction.run() called System.exit, regardless of
  if it was triggered by a call to parseArgs() or parseArgsOrExit()  The
  problem with this is that the call to System.exit() makes testing any
  code which triggers a call to HelpArgumentAction very difficult.  With
  this change, now parseArgs() raises a HelpScreenException when --help
  appears as an argument, and the caller can handle this as they see fit.
  parseArgsOrExit() exits the program if --help is supplied as an argument
  as was the case before.
