### PR TITLE
Handle enums with abstract methods

### DIFF
--- a/src/main/java/net/sourceforge/argparse4j/impl/choice/CollectionArgumentChoice.java
+++ b/src/main/java/net/sourceforge/argparse4j/impl/choice/CollectionArgumentChoice.java
@@ -69,15 +69,18 @@ public class CollectionArgumentChoice<E> implements ArgumentChoice {
             // just return false.
             return false;
         }
-        Class<?> expectedType = values_.iterator().next().getClass();
-        if (expectedType.equals(val.getClass())) {
+        Object first = values_.iterator().next();
+        if (first.getClass().equals(val.getClass())
+                || first instanceof Enum && val instanceof Enum
+                && ((Enum) first).getDeclaringClass().equals(((Enum) val).getDeclaringClass())) {
             return values_.contains(val);
         } else {
             throw new IllegalArgumentException(String.format(
                     TextHelper.LOCALE_ROOT,
                     "type mismatch (Make sure that you specified correct Argument.type()):"
                             + " expected: %s actual: %s",
-                    expectedType.getName(), val.getClass().getName()));
+                    first.getClass().getName(), val.getClass().getName()
+            ));
         }
     }
 

--- a/src/test/java/net/sourceforge/argparse4j/impl/choice/CollectionArgumentChoiceTest.java
+++ b/src/test/java/net/sourceforge/argparse4j/impl/choice/CollectionArgumentChoiceTest.java
@@ -42,4 +42,40 @@ public class CollectionArgumentChoiceTest {
         assertEquals("{1,2,3}", choice.toString());
     }
 
+
+    @Test
+    public void testSimpleEnum() {
+        CollectionArgumentChoice<Simple> c = new CollectionArgumentChoice<Simple>(Simple.values());
+        assertTrue(c.contains(Simple.B));
+    }
+
+    @Test
+    public void testAbstractEnum() {
+        CollectionArgumentChoice<Fancy> c = new CollectionArgumentChoice<Fancy>(Fancy.values());
+        assertTrue(c.contains(Fancy.B));
+    }
+
+    private static enum Simple {A, B, C}
+
+    private static enum Fancy {
+        A {
+            @Override
+            String getFoo() {
+                return "aaa";
+            }
+        },
+        B {
+            @Override
+            String getFoo() {
+                return "bbb";
+            }
+        },
+        C {
+            @Override
+            String getFoo() {
+                return "ccc";
+            }
+        };
+        abstract String getFoo();
+    }
 }


### PR DESCRIPTION
Arg parser currently throws IllegalArgumentException if you set
choices to .values() of an enum with abstract methods & pass anything other
than the first value. Use getDeclaringClass to check enum types instead of
getClass.
