### PR TITLE
Optional argument help messages now display the metavar name once.

### DIFF
--- a/src/main/java/net/sourceforge/argparse4j/internal/ArgumentImpl.java
+++ b/src/main/java/net/sourceforge/argparse4j/internal/ArgumentImpl.java
@@ -214,7 +214,7 @@ public final class ArgumentImpl implements Argument {
             StringBuilder sb = new StringBuilder();
             sb.setLength(0);
             for (String flag : flags_) {
-                if(sb.length() > 1) { 
+                if(sb.length() > 0) {
                     sb.append(", ");
                 }
                 sb.append(flag);


### PR DESCRIPTION
Hi, thank you for creating the best Java argument parser out there :)

The metavar is now printed only once, at the end of the series of flags:
-c, --create [name]  
instead of:
-c [name], --create [name]
