### PR TITLE
Convert dashes (-) to underscores (_) in arg dest for pos args

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,3 +50,8 @@ Here is summary of features:
 
 The primary documentation is done using `Sphinx
 <http://sphinx-doc.org/>`_.  You need Sphinx to run ``mvn site``.
+
+Upgrading to 0.5.0
+==================
+
+Please consult the documentation section for :doc:`migration`.

--- a/src/main/java/net/sourceforge/argparse4j/internal/ArgumentImpl.java
+++ b/src/main/java/net/sourceforge/argparse4j/internal/ArgumentImpl.java
@@ -83,7 +83,7 @@ public final class ArgumentImpl implements Argument {
                         "mutually exclusive arguments must be optional");
             }
             name_ = nameOrFlags[0];
-            dest_ = name_;
+            dest_ = name_.replace('-', '_');
         } else {
             flags_ = nameOrFlags;
             for (String flag : flags_) {

--- a/src/site/sphinx/index.rst
+++ b/src/site/sphinx/index.rst
@@ -11,6 +11,7 @@ Contents
 
    usage
    examples
+   migration
 
 Demo
 ----

--- a/src/site/sphinx/migration.rst
+++ b/src/site/sphinx/migration.rst
@@ -1,0 +1,22 @@
+Migration
+=========
+
+To 0.5.0:
+---------
+
+The rules for the default :ref:`Argument-dest` for positional arguments has
+been made consistent with options, in that the dash (`-`) character is
+is converted to an underscore (`_`)
+
+Prior to 0.5.0::
+
+    parser.addArgument("foo-bar");
+    Namespace args = parser.parseArgs(args);
+    args.get("foo-bar");
+
+Starting from 0.5.0::
+
+    parser.addArgument("foo-bar");
+    Namespace args = parser.parseArgs(args);
+    args.get("foo_bar");
+

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -1489,18 +1489,20 @@ Most :javadoc:`inf.ArgumentParser` actions add some values as an
 attribute of the object returned by |ArgumentParser.parseArgs|
 method. The name of this attribute is determined by "dest". For
 positional arguments, dest is normally supplied as the first argument
-to |ArgumentParser.addArgument| method::
+to |ArgumentParser.addArgument| method, with any internal ``-`` converted
+to ``_``::
 
     public static void main(String[] args) throws ArgumentParserException {
         ArgumentParser parser = ArgumentParsers.newArgumentParser("prog");
         parser.addArgument("bar");
+        parser.addArgument("foo-bar");
         System.out.println(parser.parseArgs(args));
     }
 
 .. code-block:: console
 
-    $ java Demo  XX
-    Namespace(bar=XX)
+    $ java Demo XX YY
+    Namespace(bar=XX, foo_bar=YY)
 
 For optional arguments, the value of dest is normally inferred from
 the option strings. :javadoc:`inf.ArgumentParser` generates the value

--- a/src/test/java/net/sourceforge/argparse4j/internal/ArgumentImplTest.java
+++ b/src/test/java/net/sourceforge/argparse4j/internal/ArgumentImplTest.java
@@ -29,6 +29,14 @@ public class ArgumentImplTest {
     }
 
     @Test
+    public void testArgumentWithDashSeparatedName() {
+        ArgumentImpl arg = new ArgumentImpl(prefix, "foo-bar");
+        assertEquals("foo-bar", arg.getName());
+        assertEquals("foo_bar", arg.getDest());
+        assertEquals("foo-bar", arg.textualName());
+    }
+
+    @Test
     public void testArgumentWithNoNameOrFlags() {
         try {
             new ArgumentImpl(prefix);


### PR DESCRIPTION
Convert dashes (-) to underscores (_) in arg dest for pos args to be consistent with how options are handled.

So that `parser.addArgument('foo-bar')` and `parser.addArgument('--foo-bar')` would both result in the namespace key to be `foo_bar`. This is also how Python's argparse works.
