### PR TITLE
Experimental JDK9 module-info support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ addons:
   apt:
     packages:
       - openjdk-6-jdk
-jdk: openjdk8
-install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgpg.skip -B -V
+jdk: openjdk9
+install:
+- export JAVA9_HOME=$JAVA_HOME
+- jdk_switcher use openjdk6
+- export JAVA6_HOME=$JAVA_HOME
+- jdk_switcher use openjdk7
+- export JAVA7_HOME=$JAVA_HOME
+- export JAVA_HOME=$JAVA9_HOME
 script:
-  - jdk_switcher use openjdk6
-  - export JAVA6_HOME=$JAVA_HOME
-  - jdk_switcher use openjdk7
-  - export JAVA7_HOME=$JAVA_HOME
-  - jdk_switcher use openjdk8
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgpg.skip -B -V "-Djdk.6.rt.jar.path=$JAVA6_HOME/jre/lib/rt.jar" "-Djdk.7.rt.jar.path=$JAVA7_HOME/jre/lib/rt.jar"
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgpg.skip -B -V

--- a/extensions/hadoop/pom.xml
+++ b/extensions/hadoop/pom.xml
@@ -25,6 +25,13 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
+            <!-- exclude missing jdk.tools:jdk.tools:1.6 dependency -->
+            <exclusions>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -124,14 +131,64 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <compilerArgs>
-                        <arg>-bootclasspath</arg>
-                        <arg>${jdk.6.rt.jar.path}</arg>
-                    </compilerArgs>
-                </configuration>
+                <executions>
+                    <!-- Disable default phase due to fixed id and position in lifecycle -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                        <!-- specify source/target for IDE integration -->
+                        <configuration>
+                            <source>9</source>
+                            <target>9</target>
+                        </configuration>
+                    </execution>
+                    <!-- Compile project with Java 9 to ensure module-info.java is valid -->
+                    <execution>
+                        <id>jdk9-module-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>9</source>
+                            <release>9</release>
+                        </configuration>
+                    </execution>
+                    <!-- Recompile as Java 6 to overwrite Java 9 class files, except module-info.java -->
+                    <execution>
+                        <id>jdk6-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>1.6</source>
+                            <target>1.6</target>
+                            <compilerArgs>
+                                <arg>-bootclasspath</arg>
+                                <arg>${jdk.6.rt.jar.path}</arg>
+                            </compilerArgs>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <!-- Compile test sources with a minimum of 1.6 -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <source>1.6</source>
+                            <target>1.6</target>
+                            <compilerArgs>
+                                <arg>-bootclasspath</arg>
+                                <arg>${jdk.6.rt.jar.path}</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>

--- a/extensions/hadoop/src/main/java/module-info.java
+++ b/extensions/hadoop/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module net.sourceforge.argparse4j.ext.hadoop {
+    requires java.base;
+    requires net.sourceforge.argparse4j;
+    requires hadoop.common;
+
+    exports net.sourceforge.argparse4j.ext.hadoop;
+}

--- a/extensions/java7/pom.xml
+++ b/extensions/java7/pom.xml
@@ -120,14 +120,64 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                    <compilerArgs>
-                        <arg>-bootclasspath</arg>
-                        <arg>${jdk.7.rt.jar.path}</arg>
-                    </compilerArgs>
-                </configuration>
+                <executions>
+                    <!-- Disable default phase due to fixed id and position in lifecycle -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                        <!-- specify source/target for IDE integration -->
+                        <configuration>
+                            <source>9</source>
+                            <target>9</target>
+                        </configuration>
+                    </execution>
+                    <!-- Compile project with Java 9 to ensure module-info.java is valid -->
+                    <execution>
+                        <id>jdk9-module-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>9</source>
+                            <release>9</release>
+                        </configuration>
+                    </execution>
+                    <!-- Recompile as Java 7 to overwrite Java 9 class files, except module-info.java -->
+                    <execution>
+                        <id>jdk7-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>1.7</source>
+                            <target>1.7</target>
+                            <compilerArgs>
+                                <arg>-bootclasspath</arg>
+                                <arg>${jdk.7.rt.jar.path}</arg>
+                            </compilerArgs>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <!-- Compile test sources with a minimum of 1.7 -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <source>1.7</source>
+                            <target>1.7</target>
+                            <compilerArgs>
+                                <arg>-bootclasspath</arg>
+                                <arg>${jdk.7.rt.jar.path}</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>

--- a/extensions/java7/src/main/java/module-info.java
+++ b/extensions/java7/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module net.sourceforge.argparse4j.ext.java7 {
+    requires java.base;
+    requires net.sourceforge.argparse4j;
+
+    exports net.sourceforge.argparse4j.ext.java7;
+}

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -136,14 +136,64 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <compilerArgs>
-                        <arg>-bootclasspath</arg>
-                        <arg>${jdk.6.rt.jar.path}</arg>
-                    </compilerArgs>
-                </configuration>
+                <executions>
+                    <!-- Disable default phase due to fixed id and position in lifecycle -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                        <!-- specify source/target for IDE integration -->
+                        <configuration>
+                            <source>9</source>
+                            <target>9</target>
+                        </configuration>
+                    </execution>
+                    <!-- Compile project with Java 9 to ensure module-info.java is valid -->
+                    <execution>
+                        <id>jdk9-module-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>9</source>
+                            <release>9</release>
+                        </configuration>
+                    </execution>
+                    <!-- Recompile as Java 6 to overwrite Java 9 class files, except module-info.java -->
+                    <execution>
+                        <id>jdk6-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>1.6</source>
+                            <target>1.6</target>
+                            <compilerArgs>
+                                <arg>-bootclasspath</arg>
+                                <arg>${jdk.6.rt.jar.path}</arg>
+                            </compilerArgs>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <!-- Compile test sources with a minimum of 1.6 -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <source>1.6</source>
+                            <target>1.6</target>
+                            <compilerArgs>
+                                <arg>-bootclasspath</arg>
+                                <arg>${jdk.6.rt.jar.path}</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>

--- a/main/src/main/java/module-info.java
+++ b/main/src/main/java/module-info.java
@@ -1,0 +1,13 @@
+module net.sourceforge.argparse4j {
+    requires java.base;
+
+    exports net.sourceforge.argparse4j;
+    exports net.sourceforge.argparse4j.annotation;
+    exports net.sourceforge.argparse4j.helper;
+    exports net.sourceforge.argparse4j.impl;
+    exports net.sourceforge.argparse4j.impl.action;
+    exports net.sourceforge.argparse4j.impl.choice;
+    exports net.sourceforge.argparse4j.impl.type;
+    exports net.sourceforge.argparse4j.inf;
+    exports net.sourceforge.argparse4j.internal;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,10 @@
     
     <properties>
         <previously.released.version>0.8.1</previously.released.version>
-        <jdk.build.rt.jar.path>${env.JAVA_HOME}/jre/lib/rt.jar</jdk.build.rt.jar.path>
-        <jdk.6.rt.jar.path>${jdk.build.rt.jar.path}</jdk.6.rt.jar.path>
-        <jdk.7.rt.jar.path>${jdk.build.rt.jar.path}</jdk.7.rt.jar.path>
+        <!-- empty path variables by default to prevent IDE errors -->
+        <!-- these variables must be set by an argument property or the JAVA6_HOME/JAVA7_HOME environment variables -->
+        <jdk.6.rt.jar.path/>
+        <jdk.7.rt.jar.path/>
     </properties>
 
     <licenses>
@@ -145,6 +146,81 @@
         </dependencies>
     </dependencyManagement>
 
+    <profiles>
+        <!-- set property 'jdk.6.rt.jar.path' based on environment variable JAVA6_HOME -->
+        <profile>
+            <id>env-java6-home</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>env.JAVA6_HOME</name>
+                </property>
+            </activation>
+            <properties>
+                <jdk.6.rt.jar.path>${env.JAVA6_HOME}/jre/lib/rt.jar</jdk.6.rt.jar.path>
+            </properties>
+        </profile>
+        <!-- set property 'jdk.7.rt.jar.path' based on environment variable JAVA7_HOME -->
+        <profile>
+            <id>env-java7-home</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>env.JAVA7_HOME</name>
+                </property>
+            </activation>
+            <properties>
+                <jdk.7.rt.jar.path>${env.JAVA7_HOME}/jre/lib/rt.jar</jdk.7.rt.jar.path>
+            </properties>
+        </profile>
+        <!-- enable validation checks unless -DskipJdkPathValidation=true is set -->
+        <profile>
+            <id>enforce-jdk-paths</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>skipJdkPathValidation</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>1.4.1</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-jdk-paths</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireProperty>
+                                            <property>jdk.6.rt.jar.path</property>
+                                            <message>A JDK 6 rt.jar path must be specified via property 'jdk.6.rt.jar.path' or derived from environment variable JAVA6_HOME</message>
+                                            <!-- require a non-empty string -->
+                                            <regex>.+</regex>
+                                            <regexMessage>A JDK 6 rt.jar path must be specified via property 'jdk.6.rt.jar.path' or derived from environment variable JAVA6_HOME</regexMessage>
+                                        </requireProperty>
+                                        <requireProperty>
+                                            <property>jdk.7.rt.jar.path</property>
+                                            <message>A JDK 7 rt.jar path must be specified via property 'jdk.7.rt.jar.path' or derived from environment variable JAVA7_HOME</message>
+                                            <!-- require a non-empty string -->
+                                            <regex>.+</regex>
+                                            <regexMessage>A JDK 7 rt.jar path must be specified via property 'jdk.7.rt.jar.path' or derived from environment variable JAVA7_HOME</regexMessage>
+                                        </requireProperty>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
@@ -159,6 +235,10 @@
                         </goals>
                         <configuration>
                             <rules>
+                                <requireJavaVersion>
+                                    <version>[1.9,)</version>
+                                    <message>A JDK 9+ installation is required to compile this Maven project</message>
+                                </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>3.0.4</version>
                                 </requireMavenVersion>
@@ -224,7 +304,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.6.2</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
@@ -244,7 +324,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.10.0</version>
+                    <version>0.14.3</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
This pull request resolves issue #123 "JDK 9+ Compatability with Project Jigsaw & module-info.class" by adding a Java 9 compilation phase in all modules and upgrading Travis CI to `openjdk9`.

<hr>

**Maven module changes:**
- `argparse4j-root`:
  - removed default values for properties `jdk.6.rt.jar.path` and `jdk.7.rt.jar.path`, as JDK9+ no longer has a `rt.jar` file; values must now be explicitly passed as Maven CLI properties (e.g. `-Djdk.6.rt.jar.path=...`) or passed through the environment variables `JAVA6_HOME` and `JAVA7_HOME`
  - added Maven property to allow skipping JDK 6/7 path validation with `-DskipJdkPathValidation=true`
  - enforce a JDK9+ `JAVA_HOME`, otherwise the build fails
  - bumped `org.apache.maven.plugins:maven-compiler-plugin` from `3.6.2` to `3.8.1` for better Java 9 support
  - bumped `com.github.siom79.japicmp:japicmp-maven-plugin` from `0.10.0` to `0.14.3` to resolve a class level error (i.e. older plugin did not support Java 9 bytecode)

- `argparse4j`, `argparse4j-java7`, `argparse4j-hadoop` (grouped for brevity): 
  - added a JDK9 module compilation phase `jdk9-module-compile` that compiles all classes to Java 9 (including `module-info.java`); this is used to generate and validate the module-info class.
  - moved the `default-compile` compilation phase to `jdk6-compile` that compiles all classes to Java 6 (or Java 7, in the case of  `argparse4j-java7`), overwriting the Java 9 classes (excluding `module-info.class`)
  - set the `default-testCompile` test compilation phase to Java 6  (or Java 7, in the case of  `argparse4j-java7`)
  - added a `module-info.java` that exposes all packages publicly, with the following module names:
    - `argparse4j` module name: `net.sourceforge.argparse4j`
    - `argparse4j-java7` module name: `net.sourceforge.argparse4j.ext.java7`
    - `argparse4j-hadoop` module name: `net.sourceforge.argparse4j.ext.hadoop`
- `argparse4j-hadoop`:
  - excluded `jdk.tools:jdk.tools` from `org.apache.hadoop:hadoop-common` due to it causing a dependency resolution error

**Caveats:**
- the `argparse4j-hadoop` module requires the Maven dependency `org.apache.hadoop:hadoop-common`, which does _not_ have a Java 9 `module-info.class`
- building the project now requires JDK 6, 7, and 9 installations

<hr>

**Travis CI Changes:**
- removed Maven install command in the `install` stage, as this was effectively building the project twice (and not _just_ downloading plugins/dependencies)
- moved/updated all JDK switching commands to `install` stage
- removed explicit `-Djdk.6.rt.jar.path=...` and `-Djdk.7.rt.jar.path=...` arguments during the `script` stage, as they are now inferred from `JAVA6_HOME` and `JAVA7_HOME`

<hr>

@jstuyts I think these changes are ready for feedback. Projects with Java 9 module support that have a `requires argparse4j` will need to migrate to `requires net.sourceforge.argparse4j`. I have granted permission for project maintainers to update my source branch `feat/jdk9-support`. I imagine the semver version needs to be updated to reflect these changes.

As an aside, this took significantly longer than I expected due to various strange Maven interactions.

Thanks in advance.