### PR TITLE
Add SubparserGroups

### DIFF
--- a/main/src/main/java/net/sourceforge/argparse4j/inf/SubparserContainer.java
+++ b/main/src/main/java/net/sourceforge/argparse4j/inf/SubparserContainer.java
@@ -1,0 +1,67 @@
+package net.sourceforge.argparse4j.inf;
+
+import net.sourceforge.argparse4j.ArgumentParsers;
+
+/**
+ * A container to which subparsers can be added.
+ */
+public interface SubparserContainer {
+
+    /**
+     * <p>
+     * Adds and returns {@link Subparser} object with given sub-command name.
+     * The given command must be unique for each SubparserContainer instance.
+     * </p>
+     * <p>
+     * The prefixChars is inherited from main ArgumentParser.
+     * </p>
+     *
+     * @param command
+     *            Sub-command name
+     * @return {@link Subparser} object.
+     */
+    Subparser addParser(String command);
+
+    /**
+     * <p>
+     * Adds and returns {@link Subparser} object with given sub-command name and
+     * addHelp. The given command must be unique for each SubparserContainer
+     * instance.
+     * </p>
+     * <p>
+     * For {@code addHelp}, see
+     * {@link ArgumentParsers#newArgumentParser(String, boolean, String)}. The
+     * prefixChars is inherited from main ArgumentParser.
+     * </p>
+     *
+     * @param command
+     *            Sub-command name
+     * @param addHelp
+     *            If true, {@code -h/--help} are available. If false, they are
+     *            not.
+     * @return {@link Subparser} object
+     */
+    Subparser addParser(String command, boolean addHelp);
+
+    /**
+     * <p>
+     * Adds and returns {@link Subparser} object with given sub-command name,
+     * addHelp and prefixChars. The given command must be unique for each
+     * SubparserContainer instance.
+     * </p>
+     * <p>
+     * For {@code addHelp}, see
+     * {@link ArgumentParsers#newArgumentParser(String, boolean, String)}.
+     * </p>
+     *
+     * @param command
+     *            Sub-command name
+     * @param addHelp
+     *            If true, {@code -h/--help} are available. If false, they are
+     *            not.
+     * @param prefixChars
+     *            The set of characters that prefix named arguments.
+     * @return {@link Subparser} object
+     */
+    Subparser addParser(String command, boolean addHelp, String prefixChars);
+}

--- a/main/src/main/java/net/sourceforge/argparse4j/inf/SubparserGroup.java
+++ b/main/src/main/java/net/sourceforge/argparse4j/inf/SubparserGroup.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2011 Tatsuhiro Tsujikawa
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.sourceforge.argparse4j.inf;
+
+/**
+ * This interface defines a method to conceptually group up {@link Subparser}
+ * objects.
+ */
+public interface SubparserGroup extends SubparserContainer {
+
+    /**
+     * <p>
+     * Sets the text to display as a title of sub-commands in the help message.
+     * </p>
+     *
+     * @param title
+     *            The text to display as a title of sub-commands
+     * @return this
+     */
+    SubparserGroup title(String title);
+}

--- a/main/src/main/java/net/sourceforge/argparse4j/inf/Subparsers.java
+++ b/main/src/main/java/net/sourceforge/argparse4j/inf/Subparsers.java
@@ -23,8 +23,6 @@
  */
 package net.sourceforge.argparse4j.inf;
 
-import net.sourceforge.argparse4j.ArgumentParsers;
-
 /**
  * <p>
  * This interface defines Subparsers which used to add {@link Subparser}.
@@ -33,68 +31,11 @@ import net.sourceforge.argparse4j.ArgumentParsers;
  * {@link Subparser} is used to add sub-command to {@link ArgumentParser}.
  * </p>
  */
-public interface Subparsers {
-
-    /**
-     * <p>
-     * Adds and returns {@link Subparser} object with given sub-command name.
-     * The given command must be unique for each Subparsers instance.
-     * </p>
-     * <p>
-     * The prefixChars is inherited from main ArgumentParser.
-     * </p>
-     * 
-     * @param command
-     *            Sub-command name
-     * @return {@link Subparser} object.
-     */
-    Subparser addParser(String command);
-
-    /**
-     * <p>
-     * Adds and returns {@link Subparser} object with given sub-command name and
-     * addHelp. The given command must be unique for each Subparsers instance.
-     * </p>
-     * <p>
-     * For {@code addHelp}, see
-     * {@link ArgumentParsers#newArgumentParser(String, boolean, String)}. The
-     * prefixChars is inherited from main ArgumentParser.
-     * </p>
-     * 
-     * @param command
-     *            Sub-command name
-     * @param addHelp
-     *            If true, {@code -h/--help} are available. If false, they are
-     *            not.
-     * @return {@link Subparser} object
-     */
-    Subparser addParser(String command, boolean addHelp);
-
-    /**
-     * <p>
-     * Adds and returns {@link Subparser} object with given sub-command name,
-     * addHelp and prefixChars. The given command must be unique for each
-     * Subparsers instance.
-     * </p>
-     * <p>
-     * For {@code addHelp}, see
-     * {@link ArgumentParsers#newArgumentParser(String, boolean, String)}.
-     * </p>
-     * 
-     * @param command
-     *            Sub-command name
-     * @param addHelp
-     *            If true, {@code -h/--help} are available. If false, they are
-     *            not.
-     * @param prefixChars
-     *            The set of characters that prefix named arguments.
-     * @return {@link Subparser} object
-     */
-    Subparser addParser(String command, boolean addHelp, String prefixChars);
+public interface Subparsers extends SubparserContainer {
 
     /**
      * Sets the name of attribute which the selected command name is stored.
-     * 
+     *
      * @param dest
      *            The name of attribute the selected command name is stored.
      * @return this.
@@ -103,7 +44,7 @@ public interface Subparsers {
 
     /**
      * Sets the text to display in the help message for sub-commands.
-     * 
+     *
      * @param help
      *            The text to display in the help message.
      * @return this
@@ -118,7 +59,7 @@ public interface Subparsers {
      * If either title or description({@link #description(String)}) is
      * specified, sub-command help will be displayed in its own group.
      * </p>
-     * 
+     *
      * @param title
      *            The text to display as a title of sub-commands
      * @return this
@@ -134,7 +75,7 @@ public interface Subparsers {
      * If either description or title({@link #title(String)}) is specified,
      * sub-command help will be displayed in its own group.
      * </p>
-     * 
+     *
      * @param description
      *            The text to display to briefly describe sub-commands
      * @return this
@@ -151,10 +92,25 @@ public interface Subparsers {
      * arbitrary string to use. This is useful if there are many sub-commands
      * and you don't want to show them all.
      * </p>
-     * 
+     *
      * @param metavar
      *            The text used to represent sub-commands in help messages
      * @return this
      */
     Subparsers metavar(String metavar);
+
+    /**
+     * <p>
+     * Adds a new SubparserGroup to the Subparsers instance.
+     * </p>
+     * <p>
+     * SubparserGroups allow to group Suparser objects into logical groups.
+     * Subparsers within a SubparserGroup are displayed separated from other
+     * Subparsers within the help menu and accept a custom title for the
+     * group.
+     * </p>
+     *
+     * @return new created SubparserGroup instance
+     */
+    SubparserGroup addSubparserGroup();
 }

--- a/main/src/main/java/net/sourceforge/argparse4j/internal/SubparserGroupImpl.java
+++ b/main/src/main/java/net/sourceforge/argparse4j/internal/SubparserGroupImpl.java
@@ -30,40 +30,39 @@ import java.util.Map;
 
 import net.sourceforge.argparse4j.helper.TextHelper;
 import net.sourceforge.argparse4j.inf.FeatureControl;
-import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.inf.SubparserGroup;
 
 /**
  * <strong>The application code must not use this class directly.</strong>
  */
-public final class SubparserGroupImpl implements SubparserGroup {
+public class SubparserGroupImpl implements SubparserGroup {
 
-    private final ArgumentParserImpl mainParser_;
+    protected final ArgumentParserImpl mainParser_;
     /**
      * The key is subparser command or alias name and value is subparser object.
      * The real command and alias names share the same subparser object. To
      * identify the aliases, check key equals to
      * {@link SubparserImpl#getCommand()}. If they are equal, it is not alias.
      */
-    private final Map<String, SubparserImpl> parsers_ = new LinkedHashMap<>();
-    private String title_ = "";
+    protected final Map<String, SubparserImpl> parsers_ = new LinkedHashMap<>();
+    protected String title_ = "";
 
     SubparserGroupImpl(ArgumentParserImpl mainParser) {
         mainParser_ = mainParser;
     }
 
     @Override
-    public Subparser addParser(String command) {
+    public SubparserImpl addParser(String command) {
         return addParser(command, true, mainParser_.getPrefixChars());
     }
 
     @Override
-    public Subparser addParser(String command, boolean addHelp) {
+    public SubparserImpl addParser(String command, boolean addHelp) {
         return addParser(command, addHelp, mainParser_.getPrefixChars());
     }
 
     @Override
-    public Subparser addParser(String command, boolean addHelp,
+    public SubparserImpl addParser(String command, boolean addHelp,
             String prefixChars) {
         if (command == null || command.isEmpty()) {
             throw new IllegalArgumentException(
@@ -94,7 +93,7 @@ public final class SubparserGroupImpl implements SubparserGroup {
         return parsers_;
     }
 
-    public void printSubparserHelp(PrintWriter writer, int format_width) {
+    void printSubparserHelp(PrintWriter writer, int format_width) {
         if (!title_.isEmpty()) {
             writer.println(" " + title_);
         }
@@ -107,8 +106,25 @@ public final class SubparserGroupImpl implements SubparserGroup {
         }
     }
 
+    /**
+     * Checks whether the SubparserGroup contains at least one Subparser.
+     *
+     * @return true if at least one Subparser is present in the group
+     */
     boolean hasSubCommand() {
-        return !parsers_.isEmpty();
+        return !getParsers().isEmpty();
+    }
+
+    /**
+     * Checks whether the specified key already exists within the parsers_ map.
+     *
+     * @param key
+     *             the key to check for
+     * @return true if the key does already exist
+     */
+    boolean containsKey(String key)
+    {
+        return getParsers().containsKey(key);
     }
 
     /**
@@ -119,7 +135,7 @@ public final class SubparserGroupImpl implements SubparserGroup {
      *         output is not suppressed.
      */
     boolean hasNotSuppressedSubCommand() {
-        for (Map.Entry<String, SubparserImpl> entry : parsers_.entrySet()) {
+        for (Map.Entry<String, SubparserImpl> entry : getParsers().entrySet()) {
             if (entry.getValue().getHelpControl() != FeatureControl.SUPPRESS) {
                 return true;
             }
@@ -133,7 +149,7 @@ public final class SubparserGroupImpl implements SubparserGroup {
      * @return collection of the sub-command name
      */
     Collection<String> getCommands() {
-        return parsers_.keySet();
+        return getParsers().keySet();
     }
 
     /**
@@ -148,7 +164,7 @@ public final class SubparserGroupImpl implements SubparserGroup {
      */
     void addAlias(SubparserImpl subparser, String... alias) {
         for (String command : alias) {
-            if (parsers_.containsKey(command)) {
+            if (containsKey(command)) {
                 throw new IllegalArgumentException(String.format(
                         TextHelper.LOCALE_ROOT,
                         "command '%s' has been already used", command));

--- a/main/src/main/java/net/sourceforge/argparse4j/internal/SubparserGroupImpl.java
+++ b/main/src/main/java/net/sourceforge/argparse4j/internal/SubparserGroupImpl.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2011 Tatsuhiro Tsujikawa
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.sourceforge.argparse4j.internal;
+
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import net.sourceforge.argparse4j.helper.TextHelper;
+import net.sourceforge.argparse4j.inf.FeatureControl;
+import net.sourceforge.argparse4j.inf.Subparser;
+import net.sourceforge.argparse4j.inf.SubparserGroup;
+
+/**
+ * <strong>The application code must not use this class directly.</strong>
+ */
+public final class SubparserGroupImpl implements SubparserGroup {
+
+    private final ArgumentParserImpl mainParser_;
+    /**
+     * The key is subparser command or alias name and value is subparser object.
+     * The real command and alias names share the same subparser object. To
+     * identify the aliases, check key equals to
+     * {@link SubparserImpl#getCommand()}. If they are equal, it is not alias.
+     */
+    private final Map<String, SubparserImpl> parsers_ = new LinkedHashMap<>();
+    private String title_ = "";
+
+    SubparserGroupImpl(ArgumentParserImpl mainParser) {
+        mainParser_ = mainParser;
+    }
+
+    @Override
+    public Subparser addParser(String command) {
+        return addParser(command, true, mainParser_.getPrefixChars());
+    }
+
+    @Override
+    public Subparser addParser(String command, boolean addHelp) {
+        return addParser(command, addHelp, mainParser_.getPrefixChars());
+    }
+
+    @Override
+    public Subparser addParser(String command, boolean addHelp,
+            String prefixChars) {
+        if (command == null || command.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "command cannot be null or empty");
+        } else if (parsers_.containsKey(command)) {
+            throw new IllegalArgumentException(String.format(
+                    TextHelper.LOCALE_ROOT,
+                    "command '%s' has been already used", command));
+        }
+        SubparserImpl parser = new SubparserImpl(
+                mainParser_.getConfig().forSubparser(addHelp, prefixChars),
+                command, mainParser_);
+        parsers_.put(command, parser);
+        return parser;
+    }
+
+    @Override
+    public SubparserGroupImpl title(String title) {
+        title_ = TextHelper.nonNull(title);
+        return this;
+    }
+
+    public String getTitle() {
+        return title_;
+    }
+
+    public Map<String, SubparserImpl> getParsers() {
+        return parsers_;
+    }
+
+    public void printSubparserHelp(PrintWriter writer, int format_width) {
+        if (!title_.isEmpty()) {
+            writer.println(" " + title_);
+        }
+        for (Map.Entry<String, SubparserImpl> entry : parsers_.entrySet()) {
+            // Don't generate help for aliases.
+            if (entry.getValue().getHelpControl() != FeatureControl.SUPPRESS &&
+                    entry.getKey().equals(entry.getValue().getCommand())) {
+                entry.getValue().printSubparserHelp(writer, format_width);
+            }
+        }
+    }
+
+    boolean hasSubCommand() {
+        return !parsers_.isEmpty();
+    }
+
+    /**
+     * Return true if SubparserImpl has at least one sub-command whose help
+     * output is not suppressed.
+     *
+     * @return true if SubparserImpl has at least one sub-command whose help
+     *         output is not suppressed.
+     */
+    boolean hasNotSuppressedSubCommand() {
+        for (Map.Entry<String, SubparserImpl> entry : parsers_.entrySet()) {
+            if (entry.getValue().getHelpControl() != FeatureControl.SUPPRESS) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns collection of the sub-command name under this object.
+     *
+     * @return collection of the sub-command name
+     */
+    Collection<String> getCommands() {
+        return parsers_.keySet();
+    }
+
+    /**
+     * Adds Subparser alias names for given Subparser. For each SubparsersImpl
+     * instance, alias names and commands must be unique. If duplication is
+     * found, {@link IllegalArgumentException} is thrown.
+     *
+     * @param subparser
+     *            Subparser to add alias names
+     * @param alias
+     *            alias name
+     */
+    void addAlias(SubparserImpl subparser, String... alias) {
+        for (String command : alias) {
+            if (parsers_.containsKey(command)) {
+                throw new IllegalArgumentException(String.format(
+                        TextHelper.LOCALE_ROOT,
+                        "command '%s' has been already used", command));
+            } else {
+                parsers_.put(command, subparser);
+            }
+        }
+    }
+}

--- a/main/src/main/java/net/sourceforge/argparse4j/internal/SubparsersImpl.java
+++ b/main/src/main/java/net/sourceforge/argparse4j/internal/SubparsersImpl.java
@@ -24,7 +24,6 @@
 package net.sourceforge.argparse4j.internal;
 
 import java.io.PrintWriter;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -37,59 +36,22 @@ import net.sourceforge.argparse4j.helper.MessageLocalization;
 import net.sourceforge.argparse4j.helper.TextHelper;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.FeatureControl;
-import net.sourceforge.argparse4j.inf.Subparsers;
 import net.sourceforge.argparse4j.inf.SubparserGroup;
+import net.sourceforge.argparse4j.inf.Subparsers;
 
 /**
  * <strong>The application code must not use this class directly.</strong>
  */
-public final class SubparsersImpl implements Subparsers {
+public final class SubparsersImpl extends SubparserGroupImpl implements Subparsers {
 
-    private final ArgumentParserImpl mainParser_;
-    /**
-     * The key is subparser command or alias name and value is subparser object.
-     * The real command and alias names share the same subparser object. To
-     * identify the aliases, check key equals to
-     * {@link SubparserImpl#getCommand()}. If they are equal, it is not alias.
-     */
-    private final Map<String, SubparserImpl> parsers_ = new LinkedHashMap<>();
     private final Set<SubparserGroupImpl> subparsers_ = new LinkedHashSet<SubparserGroupImpl>();
     private String help_ = "";
-    private String title_ = "";
     private String description_ = "";
     private String dest_ = "";
     private String metavar_ = "";
 
     SubparsersImpl(ArgumentParserImpl mainParser) {
-        mainParser_ = mainParser;
-    }
-
-    @Override
-    public SubparserImpl addParser(String command) {
-        return addParser(command, true, mainParser_.getPrefixChars());
-    }
-
-    @Override
-    public SubparserImpl addParser(String command, boolean addHelp) {
-        return addParser(command, addHelp, mainParser_.getPrefixChars());
-    }
-
-    @Override
-    public SubparserImpl addParser(String command, boolean addHelp,
-            String prefixChars) {
-        if (command == null || command.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "command cannot be null or empty");
-        } else if (parsers_.containsKey(command)) {
-            throw new IllegalArgumentException(String.format(
-                    TextHelper.LOCALE_ROOT,
-                    "command '%s' has been already used", command));
-        }
-        SubparserImpl parser = new SubparserImpl(
-                mainParser_.getConfig().forSubparser(addHelp, prefixChars),
-                command, mainParser_);
-        parsers_.put(command, parser);
-        return parser;
+        super(mainParser);
     }
 
     public SubparserGroup addSubparserGroup() {
@@ -116,10 +78,6 @@ public final class SubparsersImpl implements Subparsers {
         return this;
     }
 
-    public String getTitle() {
-        return title_;
-    }
-
     @Override
     public SubparsersImpl description(String description) {
         description_ = TextHelper.nonNull(description);
@@ -144,26 +102,6 @@ public final class SubparsersImpl implements Subparsers {
             parsers.putAll(subparsersGroup.getParsers());
 
         return parsers;
-    }
-
-    boolean hasSubCommand() {
-        return !getParsers().isEmpty();
-    }
-
-    /**
-     * Return true if SubparserImpl has at least one sub-command whose help
-     * output is not suppressed.
-     *
-     * @return true if SubparserImpl has at least one sub-command whose help
-     *         output is not suppressed.
-     */
-    boolean hasNotSuppressedSubCommand() {
-        for (Map.Entry<String, SubparserImpl> entry : getParsers().entrySet()) {
-            if (entry.getValue().getHelpControl() != FeatureControl.SUPPRESS) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**
@@ -270,37 +208,6 @@ public final class SubparsersImpl implements Subparsers {
 
             if( iterator.hasNext() )
                 writer.println();
-        }
-    }
-
-    /**
-     * Returns collection of the sub-command name under this object.
-     *
-     * @return collection of the sub-command name
-     */
-    Collection<String> getCommands() {
-        return getParsers().keySet();
-    }
-
-    /**
-     * Adds Subparser alias names for given Subparser. For each SubparsersImpl
-     * instance, alias names and commands must be unique. If duplication is
-     * found, {@link IllegalArgumentException} is thrown.
-     *
-     * @param subparser
-     *            Subparser to add alias names
-     * @param alias
-     *            alias name
-     */
-    void addAlias(SubparserImpl subparser, String... alias) {
-        for (String command : alias) {
-            if (parsers_.containsKey(command)) {
-                throw new IllegalArgumentException(String.format(
-                        TextHelper.LOCALE_ROOT,
-                        "command '%s' has been already used", command));
-            } else {
-                parsers_.put(command, subparser);
-            }
         }
     }
 


### PR DESCRIPTION
Hi there :wave: 

this PR adds a new type to *argparse4j*: `SubparserGroup`.

### Why

----

Well, we already have `ArgumentGroup` to group arguments into logical groups. For command line applications that support many different *subparsers*, a similar functionality for *subparsers* can be useful. An example that comes to my mind is `openssl` which supports a huge amount of sub-commands and groups them within the help menu:

```console
$ openssl help
Standard commands
asn1parse         ca                ciphers           cms
[...]

Message Digest commands (see the `dgst' command for more details)
blake2b512        blake2s256        gost              md4
[...]

Cipher commands (see the `enc' command for more details)
aes-128-cbc       aes-128-ecb       aes-192-cbc       aes-192-ecb
[...]
```

### What was changed?

----

Like already said, the PR adds the `SubparserGroup` type. This is basically a light version of `Subparsers` that only contains a map of `Subparser` and a title. `Subparsers` now contains an optional set of `SubparserGroup`, which stores the different groups when they are defined.

Without `SubparserGroups`, a `Subparsers` instance behaves exactly the same as before and changes should be fully backwards compatible. A `Subparsers` instance that contains groups performs most of it's operations by iterating through its own `Subparser` instances and the `Subparser` instances from the different groups. 


### How does it work?

----

Here is an example for working with `SubparserGroup`:

```java
parser = ArgumentParsers.newFor("beanshooter").build();
parser.description("beanshooter v" + ArgumentHandler.class.getPackage().getImplementationVersion() + " - a JMX Vulnerability Scanner");

Subparsers subparsers = parser.addSubparsers().help(" ").metavar(" ").dest("action");
SubparserGroup mainGroup = subparsers.addSubparserGroup().title("Basic Operations");
SubparserGroup beanGroup = subparsers.addSubparserGroup().title("MBean Operations");

mainGroup.addParser(...);
beanGroup.addParser(...);
```

The modification to the help menu is currently minimal. As already said, `SubparserGroup` only supports setting a title. One could think about descriptions too, but from my point of view, a title is sufficient. Here is the help menu generated by the example from above:

```console
usage: beanshooter [-h]   ...

beanshooter v3.0.0 - a JMX Vulnerability Scanner

positional arguments:
                          
 Basic Operations
    brute                bruteforce JMX credentials
    invoke               invoke the specified method on the specified MBean
    deploy               deploys the specified MBean on the JMX server
    enum                 enumerate the JMX service for common vulnerabilities
    list                 list available MBEans on the remote MBean server
    serial               perform a deserialization attack
    undeploy             undeploys the specified MBEAN from the JMX server

 MBean Operations
    tonka                general purpose bean for executing commands and uploading or download files
    mlet                 default JMX bean that can be used to load additional beans dynamically
    tomcat               tomcat MemoryUserDatabaseMBean used for user management

named arguments:
  -h, --help             show this help message and exit
```